### PR TITLE
preg_replace 에서 /e modifier 사용시 deprecated warning 수정

### DIFF
--- a/lib/Gnf/db/base.php
+++ b/lib/Gnf/db/base.php
@@ -695,7 +695,7 @@ namespace Gnf\db
 				$s = array_shift($args);
 				$args = array_map(array(&$this, 'escapeItem'), $args);
 
-				return preg_replace('/\?/e', 'array_shift($args)', $s, count($args));
+				return preg_replace_callback('/\?/', function ($m) use (&$args) { return array_shift($args); }, $s, count($args));
 			}
 			return "";
 		}


### PR DESCRIPTION
PHP 5.5 이상에서 preg_replace 함수 사용하는 부분에서 경고가 발생합니다.
