### PR TITLE
Added support for sqlAnd

### DIFF
--- a/lib/Gnf/db/Helper/GnfSqlAnd.php
+++ b/lib/Gnf/db/Helper/GnfSqlAnd.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gnf\db\Helper;
+
+class GnfSqlAnd
+{
+	public function __construct($in)
+	{
+		$this->dat = $in;
+	}
+}

--- a/lib/Gnf/db/base.php
+++ b/lib/Gnf/db/base.php
@@ -173,6 +173,18 @@ abstract class base implements gnfDbinterface
 				$key
 			) . ' and ' . self::escapeColumnName($key) . ' < ' . $this->escapeItemExceptNull($value->dat2, $key) . ')';
 		}
+		if (is_a($value, '\Gnf\db\Helper\GnfSqlAnd')) {
+			$ret = [];
+			foreach ($value->dat as $dat) {
+				if (is_array($dat)) {
+					$ret[] = '( ' . $this->serializeWhere($dat) . ' )';
+				}
+			}
+			if (count($ret)) {
+				return '( ' . implode(' and ', $ret) . ' )';
+			}
+			return '';
+		}
 		if (is_a($value, '\Gnf\db\Helper\GnfSqlOr')) {
 			$ret = [];
 			foreach ($value->dat as $dat) {

--- a/lib/Gnf/db/helpers.php
+++ b/lib/Gnf/db/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Gnf\db\Helper\GnfSqlAdd;
+use Gnf\db\Helper\GnfSqlAnd;
 use Gnf\db\Helper\GnfSqlBetween;
 use Gnf\db\Helper\GnfSqlColumn;
 use Gnf\db\Helper\GnfSqlGreater;
@@ -120,6 +121,42 @@ if (!function_exists('sqlWhere')) {
 	function sqlWhere(array $in)
 	{
 		return new GnfSqlWhere($in);
+	}
+}
+if (!function_exists('sqlAnd')) {
+	function sqlAnd()
+	{
+		$input = func_get_args();
+		$has_scalar_only = true;
+		foreach ($input as $v) {
+			if (!is_scalar($v)) {
+				$has_scalar_only = false;
+				break;
+			}
+		}
+		if ($has_scalar_only) {
+			return $input;
+		}
+
+		return new GnfSqlAnd($input);
+	}
+}
+if (!function_exists('sqlAndArray')) {
+	function sqlAndArray(array $args)
+	{
+		$input = $args;
+		$has_scalar_only = true;
+		foreach ($input as $v) {
+			if (!is_scalar($v)) {
+				$has_scalar_only = false;
+				break;
+			}
+		}
+		if ($has_scalar_only) {
+			return $input;
+		}
+
+		return new GnfSqlAnd($args);
 	}
 }
 if (!function_exists('sqlOr')) {


### PR DESCRIPTION
Hi~

I simply added support for 'sqlAnd, sqlAndArray' because of duplicated condition's fields.

for example)

My where conditions are:
```
[
  [        
            'book_prices.type'=> 'normal'
            'book_prices.price' => Gnf\db\Helper\GnfSqlGreater ... 
  ],
  [
            'book_prices.type' => 'rent'
            'book_prices.price' => Gnf\db\Helper\GnfSqlLesser Object ...
  ] 
];

```
And when I use gnfdb for upper conditions, It's diffcult for me to make where_clause automatically.

So I added sqlAndArray.

How about this?
Please check my code
Thx and Have a nice Day!